### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,1 @@
-# Visual Studio Online
-
-Welcome to Visual Studio Online! This environment provides you with a full-fidelity development experience, that is accessible from anywhere. It's the same Visual Studio Code experience you already know and love, only powered by the cloud 💙 ☁️
-
-Clone a repo, edit some code, [spin up a terminal](https://docs.microsoft.com/en-us/visualstudio/online/how-to/vscode#using-the-integrated-terminal) and then [start debugging](https://docs.microsoft.com/en-us/visualstudio/online/how-to/vscode#port-forwarding). When you're done working, we'll automatically suspend the environment, so you only pay for the time you actually use it (down to the second!) 👍
-
-If you're working on multiple projects, then go ahead and create multiple environments. You can quickly switch between them, knowing that each one has its own dedicated resources. Additionally, feel free to spin up environments for ad-hoc tasks such as reviewing a PR or doing some pair programming with a colleague. With Visual Studio Online, you can eradicate setup from all of your everyday tasks 🔥 🙌
-
-## Helpful Resources
-
-* [What is Visual Studio Online?](https://docs.microsoft.com/en-us/visualstudio/online/overview/what-is-vsonline)
-* [How-to Guide: VS Code](https://docs.microsoft.com/en-us/visualstudio/online/how-to/vscode#install)
-* [How-to Guide: Browser](https://docs.microsoft.com/en-us/visualstudio/online/how-to/browser#create-an-environment)
-* [Environment configuration](https://docs.microsoft.com/en-us/visualstudio/online/reference/configuring)
-* [Environment personalization](https://docs.microsoft.com/en-us/visualstudio/online/reference/personalizing)
-
-If you run into any problems, see our [troubleshooting documentation](https://docs.microsoft.com/en-us/visualstudio/online/resources/troubleshooting) for potential workarounds. Additionally, if you have any questions and/or feedback, please don't hesitate to reach out to the team on [GitHub](https://github.com/microsoftdocs/vsonline).
-
+[![Run on Repl.it](https://repl.it/badge/github/TheFoppian/Text-Based-RPG)](https://repl.it/github/TheFoppian/Text-Based-RPG)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@NihalAnand/Text-Based-RPG).